### PR TITLE
fix: change Platform dependent compilation

### DIFF
--- a/com.stansassets.plugins-dev-kit/Editor/Config/PluginsDevKitPackage.cs
+++ b/com.stansassets.plugins-dev-kit/Editor/Config/PluginsDevKitPackage.cs
@@ -10,7 +10,7 @@ namespace StansAssets.Plugins.Editor
         public static readonly string UIToolkitPath = $"{RootPath}/Editor/UIToolkit";
         public static readonly string UIToolkitControlsPath = $"{UIToolkitPath}/Controls";
 
-#if UNITY_2019_4_OR_NEWER
+#if UNITY_2019_4_OR_NEWER || UNITY_2020_2_OR_NEWER
         /// <summary>
         ///  Foundation package info.
         /// </summary>

--- a/com.stansassets.plugins-dev-kit/Editor/UIToolkit/AboutTab/AboutTab.cs
+++ b/com.stansassets.plugins-dev-kit/Editor/UIToolkit/AboutTab/AboutTab.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_2019_4_OR_NEWER
+﻿#if UNITY_2019_4_OR_NEWER || UNITY_2020_2_OR_NEWER
 namespace StansAssets.Plugins.Editor
 {
     public class AboutTab : BaseTab

--- a/com.stansassets.plugins-dev-kit/Editor/UIToolkit/SettingsWindow/BaseTab.cs
+++ b/com.stansassets.plugins-dev-kit/Editor/UIToolkit/SettingsWindow/BaseTab.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_2019_4_OR_NEWER
+﻿#if UNITY_2019_4_OR_NEWER || UNITY_2020_2_OR_NEWER
 
 using StansAssets.Foundation.Editor;
 using UnityEditor;

--- a/com.stansassets.plugins-dev-kit/Editor/UIToolkit/SettingsWindow/PackageSettingsWindow.cs
+++ b/com.stansassets.plugins-dev-kit/Editor/UIToolkit/SettingsWindow/PackageSettingsWindow.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_2019_4_OR_NEWER
+﻿#if UNITY_2019_4_OR_NEWER || UNITY_2020_2_OR_NEWER
 using System;
 using System.Collections.Generic;
 using StansAssets.Foundation.Editor;


### PR DESCRIPTION
## Purpose of this PR
<!-- Why do you submit this PR? -->
Added UNITY_2020_2_OR_NEWER to Platform dependent compilation
## Testing status
<!-- Remove the options that do not apply -->
* No tests have been added.

### Manual testing status
<!-- Describe how you tested your implementation/fix. Try to mention all the cases and flows.  -->
<!-- It will help the reviewer to understand if you missed any cases or test steps as well as will tell more about your feature or fix.   -->
Tested manually in Unity 2020.2.0a13

## Comments to reviewers
<!-- Notes for the reviewers you have assigned.  Remove if not applicable-->
