### PR TITLE
fix: window background-color for light theme

### DIFF
--- a/com.stansassets.plugins-dev-kit/Editor/UIToolkit/SettingsWindow/PackageSettingsWindowLight.uss
+++ b/com.stansassets.plugins-dev-kit/Editor/UIToolkit/SettingsWindow/PackageSettingsWindowLight.uss
@@ -1,3 +1,7 @@
+.window-root {
+    background-color: rgb(160, 160, 160);
+}
+
 SettingsBlock,
 .tabs-bar {
     background-color: rgb(190, 190, 190);


### PR DESCRIPTION
## Purpose of this PR
<!-- Why do you submit this PR? -->

## Testing status
<!-- Remove the options that do not apply -->
* No tests have been added.

### Manual testing status
<!-- Describe how you tested your implementation/fix. Try to mention all the cases and flows.  -->
<!-- It will help the reviewer to understand if you missed any cases or test steps as well as will tell more about your feature or fix.   -->
Tested manually in Unity 2019.4.10f
## Comments to reviewers
<!-- Notes for the reviewers you have assigned.  Remove if not applicable-->
