### PR TITLE
feat: get the name and the tag of a latest release in repository from…

### DIFF
--- a/com.stansassets.plugins-dev-kit/Editor/Utility/GitHubRelease.cs
+++ b/com.stansassets.plugins-dev-kit/Editor/Utility/GitHubRelease.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+
+namespace StansAssets.Plugins.Editor
+{
+    public class GitHubRelease
+    {
+        public string Name { get; private set; }
+        public string Tag { get; private set; }
+
+        public void ReadJson (string json)
+        {
+            Name = FindValueByKey ("name", json);
+            Tag = FindValueByKey ("tag_name", json);
+        }
+
+        string FindValueByKey (string key, string json)
+        {
+            // number of characters from the 1st char of the given key to the 1st char of corresponding value
+            int offsetBeforeValue = key.Length + 5; 
+            int position = json.IndexOf ("\"" + key + "\"") + offsetBeforeValue;
+            var value = (position > offsetBeforeValue) 
+                            ? new string(json.Skip (position).TakeWhile (c => c != '"').ToArray ()) 
+                            : string.Empty;
+            return value;
+        }
+    }
+}

--- a/com.stansassets.plugins-dev-kit/Editor/Utility/GitHubRelease.cs.meta
+++ b/com.stansassets.plugins-dev-kit/Editor/Utility/GitHubRelease.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ef20256522cd4339913eee76e849c638
+timeCreated: 1615401859

--- a/com.stansassets.plugins-dev-kit/Editor/Utility/GitHubUtility.cs
+++ b/com.stansassets.plugins-dev-kit/Editor/Utility/GitHubUtility.cs
@@ -1,0 +1,31 @@
+using System;
+using UnityEngine.Networking;
+
+namespace StansAssets.Plugins.Editor
+{
+    public static class GitHubUtility
+    {
+        public static void GetLatestRelease (string url, Action<GitHubRelease> callback)
+        {
+            var release = new GitHubRelease ();
+            var rq = UnityWebRequest.Get (GetReleaseInfoURL (url));
+            rq.SendWebRequest ().completed += obj => {
+                release.ReadJson (rq.downloadHandler.text);
+                callback (release);
+            };
+        }
+
+        public static string GetReleaseInfoURL (string repositoryURL)
+        {
+            if (repositoryURL.Contains ("github.com")) {
+                return repositoryURL.Replace (@".git", @"/releases/latest")
+                                    .Replace (@"ssh://git@github.com:", @"https://api.github.com/repos/");
+            }
+            else if (repositoryURL.Contains ("npmjs.org")) {
+                throw new NotImplementedException ();
+            }
+            
+            throw new NotImplementedException ();
+        }
+    }
+}

--- a/com.stansassets.plugins-dev-kit/Editor/Utility/GitHubUtility.cs.meta
+++ b/com.stansassets.plugins-dev-kit/Editor/Utility/GitHubUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a75ca5d93e3640d28b484907e79f0077
+timeCreated: 1615384062


### PR DESCRIPTION
## The feature
Using the link to GitHub repo, get a name and a tag of a latest release.

## Test
To test the feature, you can use following script:

     public class TestRepoReleaseComponent : MonoBehaviour
     {
         [SerializeField] string RepoURL = @"https://api.github.com/repos/OneSignal/OneSignal-Unity-SDK/releases/latest";
         GitHubRelease m_Release;
 
         void Start ()
         {
             GitHubUtility.GetLatestRelease (RepoURL, release => Debug.LogError ($"tag {release.Tag}; version {release.Name}"));
         }
     }